### PR TITLE
Custom fields

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,16 @@
+class UsersController < ApplicationController
+  def update
+    user = User.find(params[:id])
+    if user.update(user_params)
+      render json: user
+    else
+      render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:email, :name, :age, :gender, roles: [])
+  end
+end

--- a/app/models/concerns/custom_fields.rb
+++ b/app/models/concerns/custom_fields.rb
@@ -1,0 +1,32 @@
+module CustomFields
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def custom_fields(**attrs)
+      return unless attrs
+      return if local_stored_attributes&.[](:custom_fields).present?
+
+      labels = attrs.values.map(&:to_s)
+      differences = labels - CustomField.pluck(:label)
+      raise "Unknown custom fields: #{differences.join(', ')}" if differences.present?
+
+      store :custom_fields, accessors: attrs.keys
+      custom_fields_storage = CustomField.where(label: labels).group_by(&:label).to_h
+
+      attrs.each do |attribute, field_label|
+        custom_field = custom_fields_storage[field_label]
+
+        validators = {}
+        if custom_field.text_field?
+          validators[:format] = { with: /[a-zA-Z]/ }
+        elsif custom_field.number_field?
+          validators[:numericality] = true
+        elsif custom_field.select_field?
+          validators[:inclusion] = { in: custom_field.field_value }
+        end
+
+        validates(attribute.to_sym, **validators) if validators.present?
+      end
+    end
+  end
+end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -1,0 +1,21 @@
+class CustomField < ApplicationRecord
+  enum :field_type, {
+    text_field: 0,
+    number_field: 1,
+    single_select: 2,
+    multiple_select: 3
+  }
+
+  validates :label, presence: true, uniqueness: true
+  validate :validate_field_value, if: :select_field?
+
+  def select_field?
+    single_select? || multiple_select?
+  end
+
+  private
+
+  def validate_field_value
+    errors.add(:field_value, 'Should be an Array') unless field_value.is_a?(Array)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,8 @@
+class User < ApplicationRecord
+  include CustomFields
+
+  custom_fields name:   :text_field,
+                age:    :number_field,
+                gender: :single_select,
+                roles:  :multiple_select
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,7 @@
 class User < ApplicationRecord
   include CustomFields
 
-  custom_fields name:   :text_field,
-                age:    :number_field,
-                gender: :single_select,
-                roles:  :multiple_select
+  custom_fields :name, :age, :gender, :roles
+
+  validates :email, presence: true, uniqueness: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,3 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
+  resources :users
 end

--- a/db/migrate/20240114203736_create_users.rb
+++ b/db/migrate/20240114203736_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :email, null: false
+      t.jsonb :custom_fields, null: false, default: {}
+      t.timestamps
+    end
+
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20240114211209_create_custom_fields.rb
+++ b/db/migrate/20240114211209_create_custom_fields.rb
@@ -1,0 +1,12 @@
+class CreateCustomFields < ActiveRecord::Migration[7.0]
+  def change
+    create_table :custom_fields do |t|
+      t.string :label
+      t.integer :field_type, default: 0, limit: 2
+      t.json :field_value
+      t.timestamps
+    end
+
+    add_index :custom_fields, :label, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,34 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2024_01_14_211209) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "custom_fields", force: :cascade do |t|
+    t.string "label"
+    t.integer "field_type", limit: 2, default: 0
+    t.json "field_value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["label"], name: "index_custom_fields_on_label", unique: true
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.jsonb "custom_fields", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,10 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+CustomField.create!([
+  { label: :name, field_type: :text_field },
+  { label: :age, field_type: :number_field },
+  { label: :gender, field_type: :single_select, field_value: [:male, :female, :other] },
+  { label: :roles, field_type: :multiple_select, field_value: [:user, :hr, :pm, :admin] }
+])

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/custom_fields.yml
+++ b/test/fixtures/custom_fields.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/custom_field_test.rb
+++ b/test/models/custom_field_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CustomFieldTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Custom fields feature works via `CustomFields` concern, which should be included in each model that needs this functionality, for example:
```ruby
class User < ApplicationRecord
  include CustomFields
  
  custom_fields :name, :age, :gender, :roles
end
```

More examples from Rails console:
<img width="1421" alt="Screenshot 2024-01-15 at 11 04 30" src="https://github.com/psyxoz/test_custom_fields/assets/876346/7169ad06-8968-4bfd-9d4d-dbd26dd7c705">

